### PR TITLE
automatic selection from multi-GPU setup in motion_correction

### DIFF
--- a/motioncorr_v2.1/src/cufunc.cu
+++ b/motioncorr_v2.1/src/cufunc.cu
@@ -36,29 +36,32 @@ bool initGPU(int GPUNum)
 	{
 		return false;
 	}
-	if(GPUNum>=ngpu)
-	{
+
+	cudaError_t status;
+	if (GPUNum < 0) {
+		// loop through all devices and use first available one.
+		for (GPUNum=0; GPUNum<ngpu; GPUNum++) {
+			status = cudaSetDevice(GPUNum);
+			if (status == cudaSuccess) break;
+		}
+	}
+	else if (GPUNum < ngpu) {
+		status = cudaSetDevice(GPUNum);
+	}
+	else {
 		printf("GPU ID %d is out of range(%d). Abort.\n",GPUNum,ngpu);
 		return false;
 	}
 
-	cudaDeviceProp prop;
-	if(cudaGetDeviceProperties(&prop, GPUNum) == cudaSuccess) 
-	{
-		printf("Use GPU: #%d %s\n",GPUNum,prop.name);
-		if(prop.kernelExecTimeoutEnabled)
-		{
-			printf("Warnning: This GPU is also used for display, may not stable.\n");
+	if (status == cudaSuccess) {
+		cudaDeviceProp prop;
+		if (cudaGetDeviceProperties(&prop, GPUNum) == cudaSuccess) {
+			if(prop.kernelExecTimeoutEnabled) {
+				printf("Warnning: This GPU is also used for display, may not stable.\n");
+			}
 		}
 	}
 
-
-	if(cudaSetDevice(GPUNum)!=cudaSuccess)
-	{
-		printf("Error: Failed to set CUDA Device #%d. Abort.\n",GPUNum);
-		return false;
-	}
-	
 	signal(SIGINT, siginthandler);
 
 	return true;

--- a/motioncorr_v2.1/src/dosefgpu_driftcorr.cpp
+++ b/motioncorr_v2.1/src/dosefgpu_driftcorr.cpp
@@ -518,7 +518,7 @@ int main(int narg, char* argc[])
 	if(narg==1) 
 	{
 		printf("Dose Fractionation Tool:\n");
-		printf("Drift correction v2.1 (Nov 21, 2013)\n\n");
+		printf("Drift correction v2.1-as1 (Aug 29th, 2016)\n\n");
 		printf("    Input: InputStack.mrc [OPTION VALUE] ...\n");
 		printf("          *Note: If OPTION isn't specified, the default value will be used.\n\n");
 		printf("           OPTION     VALUE(Default)    Introduction  \n");
@@ -531,7 +531,7 @@ int main(int narg, char* argc[])
 		printf("           -ned       0                 Last frame (0-base) used in alignment. 0: Use maximum value.\n");
 		printf("           -nss       0                 First frame (0-base) used for final sum.\n");
 		printf("           -nes       0                 Last frame (0-base) used for final sum. 0: Use maximum value.\n");
-		printf("           -gpu       0                 GPU device ID.\n");
+		printf("           -gpu      -1                 GPU device ID (-1: search for first free GPU)\n");
 		printf("           -bft       150               BFactor in pix^2.\n");
 		printf("           -pbx       96                Box dimension for searching CC peak.\n");
 		printf("           -fod       2                 Number of frame offset for frame comparision.\n");


### PR DESCRIPTION
The two patches enable an automated selection of a GPU when no argument "-gpu #" is provided. 
This is useful on shared compute nodes with multiple GPU's. In our case it is a node with 4 GTX 980 cards, which is part of of larger cluster managed by gridengine. Please consider this patch for inclusion in the official release. 
